### PR TITLE
Ajout getCentroid()

### DIFF
--- a/src/DatagramGeoreferencer.hpp
+++ b/src/DatagramGeoreferencer.hpp
@@ -111,19 +111,21 @@ class DatagramGeoreferencer : public DatagramEventHandler{
                                 }
                         }
 
-			//If LGF, compute centroid
+			//If no centroid defined for LGF georeferencing, compute one
 			if(GeoreferencingLGF * lgf = dynamic_cast<GeoreferencingLGF*>(&georef)){
-				Position centroid(0,0,0,0);
+				if(lgf->getCentroid() != NULL){
+					Position centroid(0,0,0,0);
 
-				for(auto i=positions.begin();i!=positions.end();i++){
-					centroid.getVector() += i->getVector();
+					for(auto i=positions.begin();i!=positions.end();i++){
+						centroid.getVector() += i->getVector();
+					}
+
+					centroid.getVector() /= (double)positions.size();
+
+					lgf->setCentroid(&centroid);
+
+					std::cerr << "LGF centroid:" << centroid << std::endl;
 				}
-
-				centroid.getVector() /= (double)positions.size();
-
-				lgf->setCentroid(&centroid);
-
-				std::cerr << "LGF centroid:" << centroid << std::endl;
 			}
 
 			//Sort everything

--- a/src/Georeferencing.hpp
+++ b/src/Georeferencing.hpp
@@ -137,8 +137,14 @@ public:
         ecef2ned.transposeInPlace();
     }
 
+    /**
+    *  Get a pointer to the centroid
+    */
+
+    Position * getCentroid(){ return centroid;};
+
 private:
-	Position * centroid; //in geographic coordinates
+	Position * centroid = NULL; //in geographic coordinates
 	Eigen::Matrix3d ecef2ned;
 };
 


### PR DESCRIPTION
Ajout de getCentroid() pour permettre de georeferencer 2 fois sur le meme LGF