### PR TITLE
Ajouté méthode O( n log n ) pour trouver les enveloppes à HullOverlap

### DIFF
--- a/src/geometry/HullOverlap.hpp
+++ b/src/geometry/HullOverlap.hpp
@@ -130,15 +130,18 @@ public:
     * @param b projection plane coefficient 'b' in ax + by + cz + d = 0
     * @param c projection plane coefficient 'c' in ax + by + cz + d = 0
     * @param d projection plane coefficient 'd' in ax + by + cz + d = 0
+    * @param hullMethod Method to find the hulls, possible values: "PCL ConcaveHull", "Andrew's"
     * @param alpha1 Concave hull computation parameter to use with line #1
     * @param alpha2 Concave hull computation parameter to use with line #2
 	*/
     HullOverlap( pcl::PointCloud<pcl::PointXYZ>::ConstPtr line1In, 
                     pcl::PointCloud<pcl::PointXYZ>::ConstPtr line2In,
-                    double a, double b, double c, double d,
+                    double a, double b, double c, double d, std::string hullMethod = "Andrew's",
                     double alphaLine1 = 1.0, double alphaLine2 = 1.0 )
                     :   line1( line1In ), line2( line2In ),                     
                         a( a ), b( b ), c( c ), d( d ),
+                        hullMethod( hullMethod ),
+
                         alphaLine1( alphaLine1 ), alphaLine2( alphaLine2 ),
 
                         coefficients ( new pcl::ModelCoefficients() ),
@@ -161,6 +164,16 @@ public:
         coefficients->values[1] = b;
         coefficients->values[2] = c;
         coefficients->values[3] = d;
+
+        if ( hullMethod != "PCL ConcaveHull" && hullMethod != "Andrew's" )
+        {
+            std::cerr << "\n\nHullOverlap::HullOverlap(), method \""<<  hullMethod 
+                << "\" is not a valid method to find the hull.\n\n" << std::endl;
+            exit( 1 );  
+        }
+
+
+
     }
 
 
@@ -247,9 +260,9 @@ public:
 
 
 
-        const std::string method = "Andrew's";
+        // const std::string method = "Andrew's";
 
-        if ( method == "PCL ConcaveHull" )
+        if ( hullMethod == "PCL ConcaveHull" )
         {
             //http://www.pointclouds.org/documentation/tutorials/hull_2d.php
 
@@ -264,7 +277,7 @@ public:
             // Create a Concave Hull for line 2
             computeVerticesOfConcaveHull( line2InPlane2D, alphaLine2, hull2Vertices, hull2PointIndices, ! minimalMemory );    
         }
-        else if ( method == "Andrew's" )
+        else if ( hullMethod == "Andrew's" )
         {
             std::cout << "\nFinding Hull 1\n" << std::endl;
 
@@ -279,7 +292,7 @@ public:
         }
         else
         {
-            std::cerr << "\n\nHullOverlap::computeHullsAndPointsInBothHulls(), method \""<<  method 
+            std::cerr << "\n\nHullOverlap::computeHullsAndPointsInBothHulls(), method \""<<  hullMethod 
                 << "\" is not a valid method to find the hull.\n\n" << std::endl;
             exit( 1 );
         }
@@ -945,6 +958,8 @@ private:
     /**Projection plane coefficient 'd' in ax + by + cz + d = 0*/
     const double d;
 
+    //** Method to find the hulls, possible values: "PCL ConcaveHull", "Andrew's"*/
+    std::string hullMethod;
 
     /**Concave hull computation parameter to use with line #1*/
     double alphaLine1; // Alpha value to compute the concave hull for line #1

--- a/src/geometry/HullOverlap.hpp
+++ b/src/geometry/HullOverlap.hpp
@@ -311,7 +311,29 @@ public:
     }
 
 
-    bool getMinMaxPointsInOverlap( pcl::PointXYZ & minPt, pcl::PointXYZ &maxPt )
+
+    pcl::PointCloud< pcl::PointXYZ >::ConstPtr getConstPtrlineInPlane3D( const int lineNumber  ) const
+    {
+
+        if ( lineNumber < 0 || lineNumber > 1 )
+        {
+            std::cout << "\n\n----- Function HullOverlap::getConstPtrlineInPlane3D(): lineNumber parameter: "
+                << lineNumber << ".\nIt must be either 0 or 1. Returning nullptr\n" << std::endl;            
+            return nullptr;         
+        }
+
+        if ( lineNumber == 0 )
+            return line1InPlane;
+        else 
+            return line2InPlane;
+    }
+
+
+
+
+
+
+    bool getMinMaxPointsInOverlapPlane2D( pcl::PointXYZ & minPt, pcl::PointXYZ &maxPt )
     {
         bool OK = false;
 
@@ -371,6 +393,90 @@ public:
 
         return OK;
     }
+
+
+    bool getMinMaxPointsInOverlapPlane3D( pcl::PointXYZ & minPt, pcl::PointXYZ &maxPt )
+    {
+        bool OK = false;
+
+        // if there are points in both lines in the overlap
+        if ( line1InBothHullPointIndices.size() > 0 && line2InBothHullPointIndices.size() > 0 )
+        {
+
+            double xMin = std::numeric_limits<double>::max();
+            double xMax = std::numeric_limits<double>::min();
+
+            double yMin = std::numeric_limits<double>::max();
+            double yMax = std::numeric_limits<double>::min();
+
+            double zMin = std::numeric_limits<double>::max();
+            double zMax = std::numeric_limits<double>::min();            
+
+            for ( uint64_t count = 0; count < line1InBothHullPointIndices.size(); count++ )
+            {
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].x < xMin )
+                    xMin = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].x;
+
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].x > xMax )
+                    xMax = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].x;
+                    
+                    
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].y < yMin )
+                    yMin = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].y;
+
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].y > yMax )
+                    yMax = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].y;     
+
+
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].z < zMin )
+                    zMin = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].z;
+
+                if ( line1InPlane->points[ line1InBothHullPointIndices[ count ] ].z > zMax )
+                    zMax = line1InPlane->points[ line1InBothHullPointIndices[ count ] ].z;                       
+
+            }
+
+            for ( uint64_t count = 0; count < line2InBothHullPointIndices.size(); count++ )
+            {
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].x < xMin )
+                    xMin = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].x;
+
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].x > xMax )
+                    xMax = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].x;
+                    
+                    
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].y < yMin )
+                    yMin = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].y;
+
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].y > yMax )
+                    yMax = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].y;     
+
+
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].z < zMin )
+                    zMin = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].z;
+
+                if ( line2InPlane->points[ line2InBothHullPointIndices[ count ] ].z > zMax )
+                    zMax = line2InPlane->points[ line2InBothHullPointIndices[ count ] ].z;                       
+
+            }
+
+            minPt.x = xMin;
+            minPt.y = yMin;
+            minPt.z = zMin;
+
+            maxPt.x = xMax;
+            maxPt.y = yMax;
+            maxPt.z = zMax;
+
+            OK = true;
+
+        }
+
+        return OK;
+    }
+
+
+
 
     uint64_t getNbPointsInOverlap( const int lineNumber ) const
     {


### PR DESCRIPTION
La méthode de PCL qui j'utilisais jusqu'à présent est O( n² ).