### PR TITLE
String Utils tests

### DIFF
--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -46,7 +46,7 @@ bool StringUtils::ends_with_ci(const char * str, const char * suffix) {
   if(suffix_len > str_len)
   return 0;
 
-  return 0 == StringUtils::strcmpi( str + str_len - suffix_len, suffix );
+  return StringUtils::strcmpi( str + str_len - suffix_len, suffix );
 }
 
 /* Returns true if strings are equal. Case independant

--- a/src/utils/StringUtils.cpp
+++ b/src/utils/StringUtils.cpp
@@ -46,7 +46,7 @@ bool StringUtils::ends_with_ci(const char * str, const char * suffix) {
   if(suffix_len > str_len)
   return 0;
 
-  return StringUtils::strcmpi( str + str_len - suffix_len, suffix );
+  return 0 == StringUtils::strcmpi( str + str_len - suffix_len, suffix );
 }
 
 /* Returns true if strings are equal. Case independant

--- a/test/StringUtilsTest.hpp
+++ b/test/StringUtilsTest.hpp
@@ -13,7 +13,44 @@
 #include "../src/utils/StringUtils.hpp"
 #include "catch.hpp"
 
-TEST_CASE("Test the String Utils end with function")
+TEST_CASE("Test the String Utils ends_with_ci function") {
+    std::string file_s7k = "file.s7k";
+    std::string file_xtf = "file.xtf";
+    std::string file_all = "file.all";
+    
+    std::string ext_s7k = ".s7k";
+    std::string ext_xtf = ".xtf";
+    std::string ext_all = ".all";
+    
+    REQUIRE(StringUtils::ends_with_ci(file_s7k.c_str(),ext_s7k.c_str())==true);
+    REQUIRE(StringUtils::ends_with_ci(file_s7k.c_str(),ext_xtf.c_str())==false);
+    REQUIRE(StringUtils::ends_with_ci(file_s7k.c_str(),ext_all.c_str())==false);
+    
+    REQUIRE(StringUtils::ends_with_ci(file_xtf.c_str(),ext_s7k.c_str())==false);
+    REQUIRE(StringUtils::ends_with_ci(file_xtf.c_str(),ext_xtf.c_str())==true);
+    REQUIRE(StringUtils::ends_with_ci(file_xtf.c_str(),ext_all.c_str())==false);
+    
+    REQUIRE(StringUtils::ends_with_ci(file_all.c_str(),ext_s7k.c_str())==false);
+    REQUIRE(StringUtils::ends_with_ci(file_all.c_str(),ext_xtf.c_str())==false);
+    REQUIRE(StringUtils::ends_with_ci(file_all.c_str(),ext_all.c_str())==true);
+}
+
+TEST_CASE("Test the String Utils strcmpi function") {
+    std::string upper = "ABCDEF";
+    std::string lower = "abcdef";
+    std::string lower_upper = "abcDEF";
+    std::string different = "uvwxyz";
+    
+    REQUIRE(StringUtils::strcmpi(upper, lower) == true);
+    REQUIRE(StringUtils::strcmpi(upper, lower_upper) == true);
+    REQUIRE(StringUtils::strcmpi(lower, lower_upper) == true);
+    
+    REQUIRE(StringUtils::strcmpi(upper, different) == false);
+    REQUIRE(StringUtils::strcmpi(lower, different) == false);
+    REQUIRE(StringUtils::strcmpi(lower_upper, different) == false);
+}
+
+TEST_CASE("Test the String Utils ends_with function")
 {
     const char* text = NULL;
     const char* end = NULL;


### PR DESCRIPTION
Removed the 0 ==  because of the function strcmpi defined in StringUtils.

All tests pass (they fail wih 0 ==, since 0 == false return true).

```
/* Returns true if strings are equal. Case independant
 * 
 */
bool StringUtils::strcmpi(const std::string& a, const std::string& b)
{
    if (b.size() != a.size()){
        return false;
    }
    else{
	for (unsigned int i = 0; i < a.size(); ++i){
	        if (tolower(a[i]) != tolower(b[i])){
	            return false;
		}
	}
    }

    return true;
}
```